### PR TITLE
Fixed a bug in planCartesianPath method

### DIFF
--- a/src/moveit_wrapper/include/moveit_wrapper/moveit_imports.hpp
+++ b/src/moveit_wrapper/include/moveit_wrapper/moveit_imports.hpp
@@ -31,6 +31,9 @@
 
 #include <moveit_msgs/CollisionObject.h>
 
+// Time-optimal trajectory planning
+#include <moveit/trajectory_processing/time_optimal_trajectory_generation.h>
+
 // Robot State
 #include <moveit/robot_state/conversions.h>
 #include <moveit_msgs/DisplayRobotState.h>


### PR DESCRIPTION
Retiming the trajectory using [TOTG](https://moveit.picknik.ai/main/doc/concepts/trajectory_processing.html) before execution  fixes a common error related to points in a path not increasing in time while executing a Cartesian trajectory.